### PR TITLE
Return after sensor add failure.

### DIFF
--- a/src/Hub.ts
+++ b/src/Hub.ts
@@ -99,6 +99,7 @@ export class Hub extends events.EventEmitter{
                 sensor = this.sensorFactory(msg.sid, msg.model);
             }catch(e){
                 this.emit('warning', 'Could not add new sensor: ' + e.message);
+                return;
             }
         }
 


### PR DESCRIPTION
Was getting an error after a sensor failed to be loaded:
```
6 Nov 19:30:43 - [info] Server now running at http://127.0.0.1:1880/
6 Nov 19:30:43 - [info] Starting flows
6 Nov 19:30:43 - [info] Started flows
6 Nov 19:30:43 - [red] Uncaught Exception:
6 Nov 19:30:43 - TypeError: Cannot read property 'heartBeat' of null
    at Hub.onMessage (C:\Users\liam\.node-red\node_modules\node-xiaomi-smart-home\build\Hub.js:70:16)
    at emitTwo (events.js:135:13)
    at Socket.emit (events.js:224:7)
    at UDP.onMessage [as onmessage] (dgram.js:658:8)
```

Found that a return statement was missing after the error is emitted.